### PR TITLE
Updated nested serializer

### DIFF
--- a/DocumentManagement/serializers.py
+++ b/DocumentManagement/serializers.py
@@ -8,11 +8,12 @@ import io
 
 
 class DocumentSerializer(serializers.ModelSerializer):
-    files = FileSerializer(many=True, required=False)
+    #files = FileSerializer(many=True, required=False)
+    files = serializers.SerializerMethodField()
     class Meta:
         model = Document
         fields = ('id', 'owner_id', 'filename', 'files',
-                  'date_added', 'mode', 'language', 'trans_language')
+                   'date_added', 'mode', 'language', 'trans_language')
         #fields = '__all__'
         #'date_added',
 
@@ -25,6 +26,10 @@ class DocumentSerializer(serializers.ModelSerializer):
             else:
                 File.objects.create(document=document, file=file)
         return document
+
+    def get_files(self, instance):
+        file = instance.files.all().order_by('id')
+        return FileSerializer(file, many=True, required=False).data
 
 def pdf_images(document, file):
     name = str(file)[:-4]


### PR DESCRIPTION
Bug:  When updating individual files (with the update call for highlight) the ordering on the files subsection of get documents seems to reorder based on last update time , ie doesn't stay in order by id number.

To test locally (before pulling this branch), do api call for update highlight, then call get documents and see if behaves same way for you.

Hopefully, this update keeps the order by id.  Since I could not replicate bug locally, I am not 100% certain it works, but it did not break/have errors. 